### PR TITLE
KEP-976 Add dynamic peering tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bluebird": "^3.5.3",
     "chai": "^4.1.2",
     "chai-json-schema": "^1.5.0",
+    "chai-things": "^0.2.0",
     "dotenv": "^6.1.0",
     "fs": "^0.0.1-security",
     "lodash": "^4.17.10",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "chai": "^4.1.2",
     "chai-json-schema": "^1.5.0",
     "chai-things": "^0.2.0",
+    "delay": "^4.1.0",
     "dotenv": "^6.1.0",
     "fs": "^0.0.1-security",
     "lodash": "^4.17.10",

--- a/test/core-functions.test.js
+++ b/test/core-functions.test.js
@@ -10,7 +10,7 @@ describe('core functionality', () => {
 
     before('stand up swarm and client', async function () {
         this.timeout(30000);
-        swarm = await startSwarm({numOfNodes});
+        [swarm] = await startSwarm({numOfNodes});
         clientsObj.api = await initializeClient({swarm, setupDB: true});
     });
 

--- a/test/database-management.test.js
+++ b/test/database-management.test.js
@@ -12,7 +12,7 @@ describe('database management', () => {
 
     beforeEach('stand up swarm and client', async function () {
         this.timeout(30000);
-        swarm = await startSwarm({numOfNodes});
+        [swarm] = await startSwarm({numOfNodes});
         clientsObj.api = await initializeClient({swarm});
     });
 

--- a/test/dynamic-peers.test.js
+++ b/test/dynamic-peers.test.js
@@ -1,0 +1,186 @@
+const common = require('./common');
+const {startSwarm, initializeClient, teardown, spawnDaemon} = require('../utils/daemon/setup');
+const {createDirectories, generateConfigs, generatePeersList} = require('../utils/daemon/configs');
+const fsPromises = require('fs').promises;
+const waitUntil = require("async-wait-until");
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-things'));
+
+
+const numOfNodes = harnessConfigs.numOfNodes;
+
+describe('dynamic peering', () => {
+
+    before('stand up swarm and client', async function () {
+        this.timeout(30000);
+        [this.swarm, peersList] = await startSwarm({numOfNodes: 6});
+        this.api = await initializeClient({swarm: this.swarm, setupDB: true});
+    });
+
+    afterEach('remove configs and peerslist and clear harness state', function () {
+        teardown.call(this.currentTest, process.env.DEBUG_FAILS);
+    });
+
+    context('new peer bootstrapped with full peers list', function() {
+
+        before('start new peer', async function () {
+
+            const daemonDirPath = await createDirectories(1, 6);
+            const configObj = await generateConfigs({numOfConfigs: 1, pathList: daemonDirPath});
+            const data = configObj[0];
+
+            this.swarm[`daemon${data.index}`] =
+                {
+                    uuid: data.uuid,
+                    port: data.content.listener_port,
+                    http_port: data.content.http_port,
+                    index: data.index
+                };
+
+            await fsPromises.writeFile(daemonDirPath[0] + '/peers.json', JSON.stringify(peersList));
+
+            await spawnDaemon(this.swarm, 6);
+        });
+
+        it('should send request to join swarm', async function () {
+
+            await new Promise(res => {
+                this.swarm.daemon6.stream.stdout.on('data', (data) => {
+
+                    if (data.toString().includes('Sending request to join swarm')) {
+                        res();
+                    }
+                });
+            });
+        });
+
+        it('should successfully join swarm', async function () {
+
+            await new Promise(res => {
+                this.swarm.daemon6.stream.stdout.on('data', (data) => {
+
+                    if (data.toString().includes('Successfully joined the swarm')) {
+                        res();
+                    }
+                });
+            });
+        });
+
+        it('should increment swarm view number by 1', async function () {
+
+            const res = await this.api.status();
+
+            const parsedStatusJson = JSON.parse(res.moduleStatusJson).module[0].status;
+
+            console.log(parsedStatusJson.view);
+
+            await waitUntil(() => {
+
+                this.api.status().then(val => {
+
+                    const something = JSON.parse(val.moduleStatusJson).module[0].status;
+
+                    console.log(something.view);
+
+                    return (val.view === 2)
+                });
+
+            })
+        });
+
+        it('should be included in status response', async function () {
+
+            const res = await this.api.status();
+
+            const parsedStatusJson = JSON.parse(res.moduleStatusJson).module[0].status;
+
+            parsedStatusJson.peer_index.should.contain.an.item.with.property('uuid', this.swarm.daemon6.uuid)
+        });
+
+    });
+
+    context('new peer bootstrapped with one peer', function() {
+
+        before('start new peer', async function () {
+
+            const daemonDirPath = await createDirectories(1, 6);
+            const configObj = await generateConfigs({numOfConfigs: 1, pathList: daemonDirPath});
+            const data = configObj[0];
+
+            this.swarm[`daemon${data.index}`] =
+                {
+                    uuid: data.uuid,
+                    port: data.content.listener_port,
+                    http_port: data.content.http_port,
+                    index: data.index
+                };
+
+            const singlePeer = [peersList[0]];
+
+            await fsPromises.writeFile(daemonDirPath[0] + '/peers.json', JSON.stringify(singlePeer));
+
+            await spawnDaemon(this.swarm, 6);
+        });
+
+        it('should send request to join swarm', async function () {
+
+            await new Promise(res => {
+                this.swarm.daemon6.stream.stdout.on('data', (data) => {
+
+                    if (data.toString().includes('Sending request to join swarm')) {
+                        res();
+                    }
+                });
+            });
+        });
+
+        it('should successfully join swarm', async function () {
+
+            await new Promise(res => {
+                this.swarm.daemon6.stream.stdout.on('data', (data) => {
+
+                    if (data.toString().includes('Successfully joined the swarm')) {
+                        res();
+                    }
+                });
+            });
+        });
+
+        it('should increment swarm view number by 1', async function () {
+
+            const res = await this.api.status();
+
+            const parsedStatusJson = JSON.parse(res.moduleStatusJson).module[0].status;
+
+            console.log(parsedStatusJson.view);
+
+            await waitUntil(() => {
+
+                this.api.status().then(val => {
+
+                    const something = JSON.parse(val.moduleStatusJson).module[0].status;
+
+                    console.log(something.view);
+
+                    return (val.view === 2)
+                });
+
+            })
+        });
+
+        it('should be included in status response', async function () {
+
+            const res = await this.api.status();
+
+            const parsedStatusJson = JSON.parse(res.moduleStatusJson).module[0].status;
+
+            parsedStatusJson.peer_index.should.contain.an.item.with.property('uuid', this.swarm.daemon6.uuid)
+        });
+
+    });
+
+    // todo: add test for mixed configs, signing disabled
+    //  add test for old clients
+
+});

--- a/test/dynamic-peers.test.js
+++ b/test/dynamic-peers.test.js
@@ -1,5 +1,6 @@
+const assert = require('assert');
 const common = require('./common');
-const {startSwarm, initializeClient, teardown, spawnDaemon} = require('../utils/daemon/setup');
+const {startSwarm, initializeClient, teardown, spawnDaemon, createKeys} = require('../utils/daemon/setup');
 const {createDirectories, generateConfigs, generatePeersList} = require('../utils/daemon/configs');
 const fsPromises = require('fs').promises;
 const PollUntil = require('poll-until-promise');
@@ -13,99 +14,130 @@ const numOfNodes = harnessConfigs.numOfNodes;
 
 describe('dynamic peering', () => {
 
-    [{name: 'new peer bootstrapped with full peers list', numOfNodesToBootstrap: numOfNodes}, {name: 'new peer bootstrapped with one peer', numOfNodesToBootstrap: 1}].forEach((test) => {
+    [{
+        name: 'add peer with no state',
+        numOfKeys: 0
+    }, {
+        name: 'add peer with loaded db',
+        numOfKeys: 50
+    }].forEach((ctx) => {
 
-        context.only(test.name, function() {
+        context(ctx.name, function() {
+            [{
+                name: 'new peer bootstrapped with full peers list',
+                numOfNodesToBootstrap: numOfNodes
+            }, {
+                name: 'new peer bootstrapped with one peer',
+                numOfNodesToBootstrap: 1
+            }].forEach((test) => {
 
-            before('stand up swarm and client', async function () {
-                this.timeout(30000);
-                await setup.call(this, numOfNodes, test.numOfNodesToBootstrap);
-            });
+                context(test.name, function() {
 
-            after('remove configs and peerslist and clear harness state', function () {
-                teardown.call(this.currentTest, process.env.DEBUG_FAILS);
-            });
+                    before('stand up swarm and client', async function () {
+                        this.timeout(30000);
 
-            it('should successfully join swarm', async function () {
+                        [this.swarm, peersList] = await startSwarm({numOfNodes});
 
-                await new Promise(res => {
-                    this.swarm[`daemon${this.newPeerIdx}`].stream.stdout.on('data', (data) => {
+                        this.api = await initializeClient({swarm: this.swarm, setupDB: true, log: true});
 
-                        if (data.toString().includes('Successfully joined the swarm')) {
-                            res();
+                        clientsObj.api = this.api;
+
+                        if (ctx.numOfKeys > 0) {
+                            await createKeys(clientsObj, ctx.numOfKeys)
                         }
+
+                        const {daemonDirPath, data} = await generateNewPeer(numOfNodes);
+
+                        this.newPeerIdx = data.index;
+
+                        addPeerToSwarmObj.call(this, data);
+
+                        const culledPeersList = peersList.slice(0, test.numOfNodesToBootstrap);
+
+                        await writePeersList(culledPeersList, test.numOfNodesToBootstrap, daemonDirPath);
+
+                        await spawnDaemon(this.swarm, this.newPeerIdx);
                     });
-                });
-            });
 
-            it('should increment swarm view number by 1', async function () {
-                this.timeout(40000);
+                    after('remove configs and peerslist and clear harness state', function () {
+                        teardown.call(this.currentTest, process.env.DEBUG_FAILS);
+                    });
 
-                const pollView = new PollUntil();
+                    it('should successfully join swarm', async function () {
 
-                await new Promise((resolve, reject) => {
-                    pollView
-                        .stopAfter(40000)
-                        .tryEvery(2000)
-                        .execute(() => new Promise((res, rej) => {
+                        await new Promise(res => {
+                            this.swarm[`daemon${this.newPeerIdx}`].stream.stdout.on('data', (data) => {
 
-                            this.api.status().then(val => {
-
-                                const something = JSON.parse(val.moduleStatusJson).module[0].status;
-
-                                if (something.view === 2) {
-                                    return res(true)
-                                } else {
-                                    return rej()
+                                if (data.toString().includes('Successfully joined the swarm')) {
+                                    res();
                                 }
                             });
-                        }))
-                        .then(() => resolve())
-                        .catch(err => console.log(err) || reject(''))
+                        });
+                    });
+
+                    it('should increment swarm view number by 1', async function () {
+                        this.timeout(40000);
+
+                        const pollView = new PollUntil();
+
+                        await new Promise((resolve, reject) => {
+                            pollView
+                                .stopAfter(40000)
+                                .tryEvery(2000)
+                                .execute(() => new Promise((res, rej) => {
+
+                                    this.api.status().then(val => {
+
+                                        const response = JSON.parse(val.moduleStatusJson).module[0].status;
+
+                                        if (response.view === 2) {
+                                            return res(true)
+                                        } else {
+                                            return rej()
+                                        }
+                                    });
+                                }))
+                                .then(() => resolve())
+                                .catch(err => console.log(err) || reject(''))
+
+                        });
+                    });
+
+                    it('should be included in status response', async function () {
+
+                        const res = await this.api.status();
+
+                        const parsedStatusJson = JSON.parse(res.moduleStatusJson).module[0].status;
+
+                        parsedStatusJson.peer_index.should.contain.an.item.with.property('uuid', this.swarm[`daemon${this.newPeerIdx}`].uuid)
+                    });
+
+                    if (ctx.numOfKeys > 0) {
+
+                        it('should be able to fetch full keys list', async function () {
+                            assert((await clientsObj.api.keys()).length === ctx.numOfKeys);
+                        });
+
+                        it('should be able to read last key before pre-primary failure', async function () {
+                            assert((await clientsObj.api.read(`batch${ctx.numOfKeys - 1}`)) === 'value')
+                        })
+                    }
+
+                    common.crudFunctionalityTests(clientsObj);
+
+                    common.miscFunctionalityTests(clientsObj);
 
                 });
+
             });
-
-            it('should be included in status response', async function () {
-
-                const res = await this.api.status();
-
-                const parsedStatusJson = JSON.parse(res.moduleStatusJson).module[0].status;
-
-                parsedStatusJson.peer_index.should.contain.an.item.with.property('uuid', this.swarm[`daemon${this.newPeerIdx}`].uuid)
-            });
-
-            common.crudFunctionalityTests(clientsObj);
-
-            common.crudFunctionalityTests(clientsObj);
-
         });
 
-    });
+    })
 
     // todo: add test for mixed configs, signing disabled
     //  add test for old clients
 
 });
-
-async function setup(numOfNodes, numOfNodesToIncludeInPeersList) {
-    [this.swarm, peersList] = await startSwarm({numOfNodes});
-    this.api = await initializeClient({swarm: this.swarm, setupDB: true});
-
-    clientsObj.api = this.api;
-
-    const {daemonDirPath, data} = await generateNewPeer(numOfNodes);
-
-    this.newPeerIdx = data.index;
-
-    addPeerToSwarmObj.call(this, data);
-
-    const culledPeersList = peersList.slice(0, numOfNodesToIncludeInPeersList);
-
-    await writePeersList(culledPeersList, numOfNodesToIncludeInPeersList, daemonDirPath);
-
-    await spawnDaemon(this.swarm, this.newPeerIdx);
-}
 
 async function generateNewPeer(numOfExistingPeers) {
     const daemonDirPath = await createDirectories(1, numOfExistingPeers);

--- a/test/dynamic-peers.test.js
+++ b/test/dynamic-peers.test.js
@@ -12,7 +12,7 @@ const clientsObj = {};
 const numOfNodes = harnessConfigs.numOfNodes;
 
 
-describe('dynamic peering', () => {
+describe.only('dynamic peering', () => {
 
     [{
         name: 'add peer with no state',
@@ -38,7 +38,7 @@ describe('dynamic peering', () => {
 
                         [this.swarm, peersList] = await startSwarm({numOfNodes});
 
-                        this.api = await initializeClient({swarm: this.swarm, setupDB: true, log: true});
+                        this.api = await initializeClient({swarm: this.swarm, setupDB: true, log: false});
 
                         clientsObj.api = this.api;
 
@@ -76,19 +76,21 @@ describe('dynamic peering', () => {
                     });
 
                     it('should increment swarm view number by 1', async function () {
-                        this.timeout(40000);
+                        this.timeout(60000);
 
                         const pollView = new PollUntil();
 
                         await new Promise((resolve, reject) => {
                             pollView
-                                .stopAfter(40000)
+                                .stopAfter(60000)
                                 .tryEvery(2000)
                                 .execute(() => new Promise((res, rej) => {
 
                                     this.api.status().then(val => {
 
                                         const response = JSON.parse(val.moduleStatusJson).module[0].status;
+
+                                        console.log(response.view);
 
                                         if (response.view === 2) {
                                             return res(true)
@@ -110,6 +112,11 @@ describe('dynamic peering', () => {
                         const parsedStatusJson = JSON.parse(res.moduleStatusJson).module[0].status;
 
                         parsedStatusJson.peer_index.should.contain.an.item.with.property('uuid', this.swarm[`daemon${this.newPeerIdx}`].uuid)
+                    });
+
+                    it('daemons should not log rejected message', async function () {
+
+
                     });
 
                     if (ctx.numOfKeys > 0) {

--- a/test/dynamic-peers.test.js
+++ b/test/dynamic-peers.test.js
@@ -32,7 +32,7 @@ describe('dynamic peering', () => {
         hookTimeout: 100000
     }].forEach((ctx) => {
 
-        context(ctx.name, function() {
+        context(ctx.name, function () {
             [{
                 name: 'new peer bootstrapped with full peers list',
                 numOfNodesToBootstrap: numOfNodes
@@ -41,7 +41,7 @@ describe('dynamic peering', () => {
                 numOfNodesToBootstrap: 1
             }].forEach((test) => {
 
-                context(test.name, function() {
+                context(test.name, function () {
 
                     before('stand up swarm and client', async function () {
                         this.timeout(ctx.hookTimeout);
@@ -90,27 +90,23 @@ describe('dynamic peering', () => {
 
                         const pollView = new PollUntil();
 
-                        await new Promise((resolve, reject) => {
-                            pollView
-                                .stopAfter(60000)
-                                .tryEvery(2000)
-                                .execute(() => new Promise((res, rej) => {
+                        await pollView
+                            .stopAfter(60000)
+                            .tryEvery(2000)
+                            .execute(() => new Promise((res, rej) => {
 
-                                    this.api.status().then(val => {
+                                this.api.status().then(val => {
 
-                                        const response = JSON.parse(val.moduleStatusJson).module[0].status;
+                                    const response = JSON.parse(val.moduleStatusJson).module[0].status;
 
-                                        if (response.view === 2) {
-                                            return res(true)
-                                        } else {
-                                            return rej()
-                                        }
-                                    });
-                                }))
-                                .then(() => resolve())
-                                .catch(err => console.log(err) || reject(''))
+                                    if (response.view === 2) {
+                                        return res(true)
+                                    } else {
+                                        rej(false)
+                                    }
+                                });
+                            }))
 
-                        });
                     });
 
                     it('should be included in status response', async function () {

--- a/test/dynamic-peers.test.js
+++ b/test/dynamic-peers.test.js
@@ -2,180 +2,83 @@ const common = require('./common');
 const {startSwarm, initializeClient, teardown, spawnDaemon} = require('../utils/daemon/setup');
 const {createDirectories, generateConfigs, generatePeersList} = require('../utils/daemon/configs');
 const fsPromises = require('fs').promises;
-const waitUntil = require("async-wait-until");
+const PollUntil = require('poll-until-promise');
 const chai = require('chai');
 chai.should();
 chai.use(require('chai-things'));
 
-
+const clientsObj = {};
 const numOfNodes = harnessConfigs.numOfNodes;
+
 
 describe('dynamic peering', () => {
 
-    before('stand up swarm and client', async function () {
-        this.timeout(30000);
-        [this.swarm, peersList] = await startSwarm({numOfNodes: 6});
-        this.api = await initializeClient({swarm: this.swarm, setupDB: true});
-    });
+    [{name: 'new peer bootstrapped with full peers list', numOfNodesToBootstrap: numOfNodes}, {name: 'new peer bootstrapped with one peer', numOfNodesToBootstrap: 1}].forEach((test) => {
 
-    afterEach('remove configs and peerslist and clear harness state', function () {
-        teardown.call(this.currentTest, process.env.DEBUG_FAILS);
-    });
+        context.only(test.name, function() {
 
-    context('new peer bootstrapped with full peers list', function() {
+            before('stand up swarm and client', async function () {
+                this.timeout(30000);
+                await setup.call(this, numOfNodes, test.numOfNodesToBootstrap);
+            });
 
-        before('start new peer', async function () {
+            after('remove configs and peerslist and clear harness state', function () {
+                teardown.call(this.currentTest, process.env.DEBUG_FAILS);
+            });
 
-            const daemonDirPath = await createDirectories(1, 6);
-            const configObj = await generateConfigs({numOfConfigs: 1, pathList: daemonDirPath});
-            const data = configObj[0];
+            it('should successfully join swarm', async function () {
 
-            this.swarm[`daemon${data.index}`] =
-                {
-                    uuid: data.uuid,
-                    port: data.content.listener_port,
-                    http_port: data.content.http_port,
-                    index: data.index
-                };
+                await new Promise(res => {
+                    this.swarm[`daemon${this.newPeerIdx}`].stream.stdout.on('data', (data) => {
 
-            await fsPromises.writeFile(daemonDirPath[0] + '/peers.json', JSON.stringify(peersList));
-
-            await spawnDaemon(this.swarm, 6);
-        });
-
-        it('should send request to join swarm', async function () {
-
-            await new Promise(res => {
-                this.swarm.daemon6.stream.stdout.on('data', (data) => {
-
-                    if (data.toString().includes('Sending request to join swarm')) {
-                        res();
-                    }
+                        if (data.toString().includes('Successfully joined the swarm')) {
+                            res();
+                        }
+                    });
                 });
             });
-        });
 
-        it('should successfully join swarm', async function () {
+            it('should increment swarm view number by 1', async function () {
+                this.timeout(40000);
 
-            await new Promise(res => {
-                this.swarm.daemon6.stream.stdout.on('data', (data) => {
+                const pollView = new PollUntil();
 
-                    if (data.toString().includes('Successfully joined the swarm')) {
-                        res();
-                    }
+                await new Promise((resolve, reject) => {
+                    pollView
+                        .stopAfter(40000)
+                        .tryEvery(2000)
+                        .execute(() => new Promise((res, rej) => {
+
+                            this.api.status().then(val => {
+
+                                const something = JSON.parse(val.moduleStatusJson).module[0].status;
+
+                                if (something.view === 2) {
+                                    return res(true)
+                                } else {
+                                    return rej()
+                                }
+                            });
+                        }))
+                        .then(() => resolve())
+                        .catch(err => console.log(err) || reject(''))
+
                 });
             });
-        });
 
-        it('should increment swarm view number by 1', async function () {
+            it('should be included in status response', async function () {
 
-            const res = await this.api.status();
+                const res = await this.api.status();
 
-            const parsedStatusJson = JSON.parse(res.moduleStatusJson).module[0].status;
+                const parsedStatusJson = JSON.parse(res.moduleStatusJson).module[0].status;
 
-            console.log(parsedStatusJson.view);
-
-            await waitUntil(() => {
-
-                this.api.status().then(val => {
-
-                    const something = JSON.parse(val.moduleStatusJson).module[0].status;
-
-                    console.log(something.view);
-
-                    return (val.view === 2)
-                });
-
-            })
-        });
-
-        it('should be included in status response', async function () {
-
-            const res = await this.api.status();
-
-            const parsedStatusJson = JSON.parse(res.moduleStatusJson).module[0].status;
-
-            parsedStatusJson.peer_index.should.contain.an.item.with.property('uuid', this.swarm.daemon6.uuid)
-        });
-
-    });
-
-    context('new peer bootstrapped with one peer', function() {
-
-        before('start new peer', async function () {
-
-            const daemonDirPath = await createDirectories(1, 6);
-            const configObj = await generateConfigs({numOfConfigs: 1, pathList: daemonDirPath});
-            const data = configObj[0];
-
-            this.swarm[`daemon${data.index}`] =
-                {
-                    uuid: data.uuid,
-                    port: data.content.listener_port,
-                    http_port: data.content.http_port,
-                    index: data.index
-                };
-
-            const singlePeer = [peersList[0]];
-
-            await fsPromises.writeFile(daemonDirPath[0] + '/peers.json', JSON.stringify(singlePeer));
-
-            await spawnDaemon(this.swarm, 6);
-        });
-
-        it('should send request to join swarm', async function () {
-
-            await new Promise(res => {
-                this.swarm.daemon6.stream.stdout.on('data', (data) => {
-
-                    if (data.toString().includes('Sending request to join swarm')) {
-                        res();
-                    }
-                });
+                parsedStatusJson.peer_index.should.contain.an.item.with.property('uuid', this.swarm[`daemon${this.newPeerIdx}`].uuid)
             });
-        });
 
-        it('should successfully join swarm', async function () {
+            common.crudFunctionalityTests(clientsObj);
 
-            await new Promise(res => {
-                this.swarm.daemon6.stream.stdout.on('data', (data) => {
+            common.crudFunctionalityTests(clientsObj);
 
-                    if (data.toString().includes('Successfully joined the swarm')) {
-                        res();
-                    }
-                });
-            });
-        });
-
-        it('should increment swarm view number by 1', async function () {
-
-            const res = await this.api.status();
-
-            const parsedStatusJson = JSON.parse(res.moduleStatusJson).module[0].status;
-
-            console.log(parsedStatusJson.view);
-
-            await waitUntil(() => {
-
-                this.api.status().then(val => {
-
-                    const something = JSON.parse(val.moduleStatusJson).module[0].status;
-
-                    console.log(something.view);
-
-                    return (val.view === 2)
-                });
-
-            })
-        });
-
-        it('should be included in status response', async function () {
-
-            const res = await this.api.status();
-
-            const parsedStatusJson = JSON.parse(res.moduleStatusJson).module[0].status;
-
-            parsedStatusJson.peer_index.should.contain.an.item.with.property('uuid', this.swarm.daemon6.uuid)
         });
 
     });
@@ -184,3 +87,43 @@ describe('dynamic peering', () => {
     //  add test for old clients
 
 });
+
+async function setup(numOfNodes, numOfNodesToIncludeInPeersList) {
+    [this.swarm, peersList] = await startSwarm({numOfNodes});
+    this.api = await initializeClient({swarm: this.swarm, setupDB: true});
+
+    clientsObj.api = this.api;
+
+    const {daemonDirPath, data} = await generateNewPeer(numOfNodes);
+
+    this.newPeerIdx = data.index;
+
+    addPeerToSwarmObj.call(this, data);
+
+    const culledPeersList = peersList.slice(0, numOfNodesToIncludeInPeersList);
+
+    await writePeersList(culledPeersList, numOfNodesToIncludeInPeersList, daemonDirPath);
+
+    await spawnDaemon(this.swarm, this.newPeerIdx);
+}
+
+async function generateNewPeer(numOfExistingPeers) {
+    const daemonDirPath = await createDirectories(1, numOfExistingPeers);
+    const configObj = await generateConfigs({numOfConfigs: 1, pathList: daemonDirPath});
+    const data = configObj[0];
+    return {daemonDirPath, data};
+}
+
+function addPeerToSwarmObj(data) {
+    this.swarm[`daemon${data.index}`] =
+        {
+            uuid: data.uuid,
+            port: data.content.listener_port,
+            http_port: data.content.http_port,
+            index: data.index
+        };
+}
+
+async function writePeersList(peersList, numOfNodesToIncludeInPeersList, daemonDirPath) {
+    await fsPromises.writeFile(daemonDirPath[0] + '/peers.json', JSON.stringify(peersList));
+}

--- a/test/multiclient.test.js
+++ b/test/multiclient.test.js
@@ -12,7 +12,7 @@ describe('multi-client', () => {
 
     beforeEach('stand up swarm and client', async function () {
         this.timeout(30000);
-        swarm = await startSwarm({numOfNodes});
+        [swarm] = await startSwarm({numOfNodes});
 
         const client1 = {uuid: '4982e0b0-0b2f-4c3a-b39f-26878e2ac814', pem: 'MHQCAQEEIFH0TCvEu585ygDovjHE9SxW5KztFhbm4iCVOC67h0tEoAcGBSuBBAAKoUQDQgAE9Icrml+X41VC6HTX21HulbJo+pV1mtWn4+evJAi8ZeeLEJp4xg++JHoDm8rQbGWfVM84eqnb/RVuIXqoz6F9Bg=='};
         const client2 = {uuid: '71e2cd35-b606-41e6-bb08-f20de30df76c', pem: 'MHQCAQEEIFH0TCvEu585ygDovjHE9SxW5KztFhbm4iCVOC67h0tEoAcGBSuBBAAKoUQDQgAE9Icrml+X41VC6HTX21HulbJo+pV1mtWn4+evJAi8ZeeLEJp4xg++JHoDm8rQbGWfVM84eqnb/RVuIXqoz6F9Bg=='};

--- a/test/pbft.test.js
+++ b/test/pbft.test.js
@@ -24,7 +24,7 @@ describe('pbft', () => {
 
     beforeEach('stand up swarm and client', async function () {
         this.timeout(30000);
-        swarm = await startSwarm({numOfNodes});
+        [swarm] = await startSwarm({numOfNodes});
         clientsObj.api = await initializeClient({swarm, setupDB: true});
     });
 

--- a/test/permissions.test.js
+++ b/test/permissions.test.js
@@ -35,7 +35,7 @@ describe('permissions', () => {
 
     before('stand up swarm and client', async function () {
         this.timeout(30000);
-        swarm = await startSwarm({numOfNodes});
+        [swarm] = await startSwarm({numOfNodes});
         clientsObj.api = await initializeClient({swarm, setupDB: true, uuid: '4982e0b0-0b2f-4c3a-b39f-26878e2ac814', pem: 'MHQCAQEEIFH0TCvEu585ygDovjHE9SxW5KztFhbm4iCVOC67h0tEoAcGBSuBBAAKoUQDQgAE9Icrml+X41VC6HTX21HulbJo+pV1mtWn4+evJAi8ZeeLEJp4xg++JHoDm8rQbGWfVM84eqnb/RVuIXqoz6F9Bg=='});
         await clientsObj.api.create('updateKey', 'value--1');
     });

--- a/test/quick-read.test.js
+++ b/test/quick-read.test.js
@@ -10,7 +10,7 @@ describe('quick read', () => {
 
     beforeEach('stand up swarm and client', async function () {
         this.timeout(30000);
-        swarm = await startSwarm({numOfNodes});
+        [swarm] = await startSwarm({numOfNodes});
         clientsObj.api = await initializeClient({swarm, setupDB: true});
 
         await clientsObj.api.create('hello', 'world');

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -10,7 +10,7 @@ describe('status', () => {
 
     before('stand up swarm and client', async function () {
         this.timeout(30000);
-        this.swarm = await startSwarm({numOfNodes});
+        [this.swarm] = await startSwarm({numOfNodes});
         this.api = await initializeClient({swarm: this.swarm, setupDB: true});
     });
 

--- a/test/view-change.test.js
+++ b/test/view-change.test.js
@@ -30,7 +30,7 @@ describe('view change', function () {
             before(async function () {
                 this.timeout(100000);
 
-                this.swarm = await startSwarm({numOfNodes});
+                [this.swarm] = await startSwarm({numOfNodes});
                 this.api = await initializeClient({swarm: this.swarm, setupDB: true});
 
                 if (ctx.numOfKeys > 0) {
@@ -111,7 +111,7 @@ describe('view change', function () {
         before(async function () {
             this.timeout(30000);
 
-            this.swarm = await startSwarm({numOfNodes});
+            [this.swarm] = await startSwarm({numOfNodes});
             this.api = await initializeClient({swarm: this.swarm, setupDB: true});
 
             this.keysInFlight = 30;
@@ -149,7 +149,7 @@ describe('view change', function () {
         before(async function () {
             this.timeout(30000);
 
-            this.swarm = await startSwarm({numOfNodes});
+            [this.swarm] = await startSwarm({numOfNodes});
             this.api = await initializeClient({swarm: this.swarm, setupDB: true});
 
             killPrimary.call(this);

--- a/utils/daemon/configs.js
+++ b/utils/daemon/configs.js
@@ -18,7 +18,6 @@ const configUtils = {
         numOfConfigs = typeof numOfConfigs === 'number' ? numOfConfigs : parseInt(numOfConfigs);
 
         if (!preserveConfigCounter) {
-            console.log('resetting')
             configUtils.resetDaemonConfigCounter();
         }
 

--- a/utils/daemon/setup.js
+++ b/utils/daemon/setup.js
@@ -78,17 +78,18 @@ const spawnSwarm = async (swarm, {consensusAlgorithm = 'pbft', partialSpawn, mai
         await Promise.all(nodesToSpawn.map((daemon) => new Promise((res, rej) => {
 
             const daemonTimeout = setTimeout(() => {
-                rej(new Error(`${daemon} stdout: \n ${buffer}`))
+                rej(new Error(`${daemon} stdout: \n ${output}`))
             }, 15000);
 
-            let buffer = '';
+            let output = '';
 
             swarm[daemon].stream = spawn('script', ['-q', '/dev/null', './run-daemon.sh', `bluzelle${swarm[daemon].index}.json`, `daemon${swarm[daemon].index}`], {cwd: './scripts'});
 
-            swarm[daemon].stream.stdout.on('data', (data) => {
-                buffer += data.toString();
+            swarm[daemon].stream.stdout.on('data', (buffer) => {
+                let data = buffer.toString();
+                output += data;
 
-                if (data.toString().includes('Running node with ID:')) {
+                if (data.includes('Running node with ID:')) {
                     clearInterval(daemonTimeout);
                     swarm.pushLiveNodes(daemon);
                     res();

--- a/utils/daemon/setup.js
+++ b/utils/daemon/setup.js
@@ -71,8 +71,6 @@ const spawnSwarm = async (swarm, {consensusAlgorithm = 'pbft', partialSpawn, mai
 
     const nodesToSpawn = partialSpawn ? nodeNames.slice(0, partialSpawn) : nodeNames;
 
-    const MINIMUM_NODES = Math.floor(nodesToSpawn.length * (1 - failureAllowed));
-
     // todo: refactor to use spawnDaemon
     //  handle etherscan.io hangs by retrying
 

--- a/utils/daemon/swarm.js
+++ b/utils/daemon/swarm.js
@@ -67,6 +67,36 @@ module.exports = class SwarmState {
         }
     }
 
+    addMultipleFailureListeners (array) {
+        array.forEach(([msg, times]) => {
+            this.addFailureListener(msg, times)
+        })
+    }
+
+    addFailureListener (msg, times) {
+        const daemonObjects = Object.entries(this).filter(prop => prop[0].includes('daemon'));
+
+        daemonObjects.forEach(([key, value]) => {
+
+            let count = 0;
+            if (value.stream !== null)  {
+
+                value.stream.stdout.on('data', (buffer) => {
+
+                    let data = buffer.toString();
+
+                    if (data.includes(msg)) {
+
+                        if (++count >= times) {
+                            throw new Error(`"${msg}" was logged >= ${times} times in ${key}. \n ${data}`);
+                        }
+                    };
+                });
+            }
+        });
+    };
+
+
     load(configsObject) {
 
         const _temp = [];

--- a/utils/daemon/swarm.js
+++ b/utils/daemon/swarm.js
@@ -88,7 +88,7 @@ module.exports = class SwarmState {
                     if (data.includes(msg)) {
 
                         if (++count >= times) {
-                            throw new Error(`"${msg}" was logged >= ${times} times in ${key}. \n ${data}`);
+                            console.log(`"${msg}" was logged >= ${times} times in ${key}. \n ${data}`);
                         }
                     };
                 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,11 @@ browser-stdout@1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
+chai-things@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/chai-things/-/chai-things-0.2.0.tgz#c55128378f9bb399e994f00052151984ed6ebe70"
+  integrity sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=
+
 chai-json-schema@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/chai-json-schema/-/chai-json-schema-1.5.0.tgz#6960719e40f71fd5b377c9282e5c9a46799474f6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,11 +40,6 @@ browser-stdout@1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-chai-things@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/chai-things/-/chai-things-0.2.0.tgz#c55128378f9bb399e994f00052151984ed6ebe70"
-  integrity sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=
-
 chai-json-schema@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/chai-json-schema/-/chai-json-schema-1.5.0.tgz#6960719e40f71fd5b377c9282e5c9a46799474f6"
@@ -52,6 +47,11 @@ chai-json-schema@^1.5.0:
   dependencies:
     jsonpointer.js "0.4.0"
     tv4 "~1.2.7"
+
+chai-things@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/chai-things/-/chai-things-0.2.0.tgz#c55128378f9bb399e994f00052151984ed6ebe70"
+  integrity sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=
 
 chai@^4.1.2:
   version "4.1.2"
@@ -170,9 +170,9 @@ jsonpointer.js@0.4.0:
   integrity sha1-ACyxI/dnqv3rAZYTLOXE+ZQcyro=
 
 lodash@^4.17.10:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,6 +94,11 @@ deep-eql@^3.0.0:
   dependencies:
     type-detect "^4.0.0"
 
+delay@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/delay/-/delay-4.1.0.tgz#474cd28809da41d1a048a70a1d835f47ac377cd2"
+  integrity sha512-8Hea6/aOu3bPdDBQhSRUEUzF0QwuWmSPuIK+sxNdvcJtSfzb6HXrTd9DFJBCJcV9o83fFECqTgllqdnmUfq9+w==
+
 diff@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"


### PR DESCRIPTION
* Added dynamic peer tests
* Added swarm method to add message listeners to daemon stdouts. Used to catch swarm errors that are transient and not tied to any specific test.
* Tweaked view change tests
* Small changes in various other tests necessary after swarm setup changed