### PR TITLE
KEP-1572 Fix multi-client colliding uuid test setup

### DIFF
--- a/tests/functional/multiclient.test.js
+++ b/tests/functional/multiclient.test.js
@@ -156,6 +156,8 @@ function localSwarmHooks() {
             uuid: UUIDS.client2
         });
         this.api2 = client2Apis[0];
+
+        this.esrAddress = this.swarmManager.getEsrContractAddress();
     });
 
     stopSwarmsAndRemoveStateHook({afterHook: after, preserveSwarmState: false});


### PR DESCRIPTION
Forgot to set `this.esrAddress` when running local swarm tests