### PR TITLE
KEP-1402/1403 Root key database permissioning tests

### DIFF
--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -1,17 +1,18 @@
 const {wrappedError} = require('../src/utils');
 
-const initializeClient = async ({log = false, logDetailed = false, createDB, ethereum_rpc = harnessConfigs.ethereumRpc, esrContractAddress, private_pem = harnessConfigs.masterPrivateKey, public_pem = harnessConfigs.masterPublicKey, uuid = harnessConfigs.defaultUuid}) => {
+const initializeClient = async ({createDB, uuid = harnessConfigs.defaultUuid, ethereum_rpc = harnessConfigs.ethereumRpc, esrContractAddress = harnessConfigs.esrContractAddress, private_pem = harnessConfigs.masterPrivateKey, public_pem = harnessConfigs.masterPublicKey, log = false, logDetailed = false} = {}) => {
 
     let apis;
 
     try {
         apis = await bluzelle({
+            _connect_to_all: true,
+
             uuid,
             ethereum_rpc,
             contract_address: esrContractAddress,
             private_pem,
             public_pem,
-            _connect_to_all: true,
             log,
             logDetailed
         });
@@ -36,8 +37,8 @@ const createKeys = async (clientObj, numOfKeys, base = 'batch', value = 'value')
     const keys = [...Array(numOfKeys).fill(base).map(concatenateValueWithIndex)];
 
     await keys.reduce((p, key) =>
-        p.then(() => clientObj.api.create(key, value))
-            , Promise.resolve());
+            p.then(() => clientObj.api.create(key, value))
+        , Promise.resolve());
 
     return {keys, value};
 };

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -5,7 +5,7 @@ const {pipe, invoke} = require('lodash/fp');
 exports.generateKeys = (path) => {
 
     try {
-        execSync(`openssl ecparam -name secp256r1 -genkey -noout -out ${path}/private-key.pem`);
+        execSync(`openssl ecparam -name prime256v1 -genkey -noout -out ${path}/private-key.pem`);
         execSync(`openssl ec -in ${path}/private-key.pem -pubout -out ${path}/public-key.pem > /dev/null 2>&1`);
     } catch (err) {
         throw new Error(`Error generating Daemon keys \n${err}`)

--- a/src/daemonManager.test.js
+++ b/src/daemonManager.test.js
@@ -7,109 +7,155 @@ describe('daemonManager', function () {
 
     const numberOfDaemons = 3;
 
-    beforeEach('generateSwarm', async function () {
-        this.swarmManager = await swarmManager();
-        this.swarm = await this.swarmManager.generateSwarm({numberOfDaemons});
-    });
+    context('general functionality', function () {
+        beforeEach('generateSwarm', async function () {
+            this.swarmManager = await swarmManager();
+            this.swarm = await this.swarmManager.generateSwarm({numberOfDaemons});
+        });
 
-    afterEach('stop swarm', async function () {
-        await this.swarm.stop();
-        this.swarmManager.removeSwarmState();
-    });
+        afterEach('stop swarm', async function () {
+            await this.swarm.stop();
+            this.swarmManager.removeSwarmState();
+        });
 
-    it('swarm should have correct number of daemons', function () {
-        this.swarm.getDaemons().should.have.lengthOf(numberOfDaemons)
-    });
+        it('swarm should have correct number of daemons', function () {
+            this.swarm.getDaemons().should.have.lengthOf(numberOfDaemons)
+        });
 
-    it('should be able to query daemon running status', function () {
-        this.swarm.getDaemons().map(daemon => daemon.isRunning()).should.all.be.equal(false)
-    });
+        it('should be able to query daemon running status', function () {
+            this.swarm.getDaemons().map(daemon => daemon.isRunning()).should.all.be.equal(false)
+        });
 
-    it('should be able to start daemons', async function () {
-        await this.swarm.start();
+        it('should be able to start daemons', async function () {
+            await this.swarm.start();
 
-        this.swarm.getDaemons().map(daemon => daemon.isRunning()).should.all.be.equal(true)
-    });
+            this.swarm.getDaemons().map(daemon => daemon.isRunning()).should.all.be.equal(true)
+        });
 
-    it('should be able to stop all daemons', async function () {
-        await this.swarm.start();
-        await this.swarm.stop();
+        it('should be able to stop all daemons', async function () {
+            await this.swarm.start();
+            await this.swarm.stop();
 
-        this.swarm.getDaemons().map(daemon => daemon.isRunning()).should.all.be.equal(false);
-    });
+            this.swarm.getDaemons().map(daemon => daemon.isRunning()).should.all.be.equal(false);
+        });
 
-    it('should be able to start a select number of daemons', async function () {
-        await this.swarm.startPartial(2);
+        it('should be able to start a select number of daemons', async function () {
+            await this.swarm.startPartial(2);
 
-        this.swarm.getDaemons().map(daemon => daemon.isRunning()).should.deep.equal([true, true, false]);
-    });
+            this.swarm.getDaemons().map(daemon => daemon.isRunning()).should.deep.equal([true, true, false]);
+        });
 
-    it('should be able to start unstarted daemons', async function () {
-        await this.swarm.startPartial(1);
-        await this.swarm.startUnstarted();
+        it('should be able to start unstarted daemons', async function () {
+            await this.swarm.startPartial(1);
+            await this.swarm.startUnstarted();
 
-        this.swarm.getDaemons().map(daemon => daemon.isRunning()).should.all.be.equal(true);
-    });
+            this.swarm.getDaemons().map(daemon => daemon.isRunning()).should.all.be.equal(true);
+        });
 
-    it('should be able to add daemon to unstarted swarm', async function () {
-        await this.swarm.addDaemon();
+        it('should be able to add daemon to unstarted swarm', async function () {
+            await this.swarm.addDaemon();
 
-        this.swarm.getDaemons().should.have.lengthOf(numberOfDaemons + 1);
-    });
+            this.swarm.getDaemons().should.have.lengthOf(numberOfDaemons + 1);
+        });
 
-    it('should be able to add daemon to started swarm', async function () {
-        await this.swarm.start();
-        await this.swarm.addDaemon();
+        it('should be able to add daemon to started swarm', async function () {
+            await this.swarm.start();
+            await this.swarm.addDaemon();
 
-        this.swarm.getDaemons().should.have.lengthOf(numberOfDaemons + 1);
-    });
+            this.swarm.getDaemons().should.have.lengthOf(numberOfDaemons + 1);
+        });
 
-    it('unstarted new daemon should have correct isRunning status', async function () {
-        await this.swarm.start();
-        await this.swarm.addDaemon();
+        it('unstarted new daemon should have correct isRunning status', async function () {
+            await this.swarm.start();
+            await this.swarm.addDaemon();
 
-        last(this.swarm.getDaemons()).isRunning().should.equal(false);
-    });
+            last(this.swarm.getDaemons()).isRunning().should.equal(false);
+        });
 
-    it('starting new daemon should change isRunning status', async function () {
-        await this.swarm.start();
-        await this.swarm.addDaemon();
-        await this.swarm.startUnstarted();
+        it('starting new daemon should change isRunning status', async function () {
+            await this.swarm.start();
+            await this.swarm.addDaemon();
+            await this.swarm.startUnstarted();
 
-        last(this.swarm.getDaemons()).isRunning().should.equal(true);
-    });
+            last(this.swarm.getDaemons()).isRunning().should.equal(true);
+        });
 
-    it('should be able to stop daemons selectively', async function () {
-        await this.swarm.start();
-        const randomDaemon = random(numberOfDaemons - 1, 0);
-        await this.swarm.getDaemons()[randomDaemon].stop();
+        it('should be able to stop daemons selectively', async function () {
+            await this.swarm.start();
+            const randomDaemon = random(numberOfDaemons - 1, 0);
+            await this.swarm.getDaemons()[randomDaemon].stop();
 
-        this.swarm.getDaemons()[randomDaemon].isRunning().should.equal(false);
-    });
+            this.swarm.getDaemons()[randomDaemon].isRunning().should.equal(false);
+        });
 
-    it('should be able to restart daemons selectively', async function () {
-        await this.swarm.start();
-        const randomDaemon = random(numberOfDaemons - 1, 0);
-        await this.swarm.getDaemons()[randomDaemon].restart()
-    });
+        it('should be able to restart daemons selectively', async function () {
+            await this.swarm.start();
+            const randomDaemon = random(numberOfDaemons - 1, 0);
+            await this.swarm.getDaemons()[randomDaemon].restart()
+        });
 
-    it('should be able to read daemon streams', async function () {
-        await this.swarm.start();
+        it('should be able to read daemon streams', async function () {
+            await this.swarm.start();
 
-        this.swarm.getDaemons().forEach(daemon => {
-            daemon.getProcess().stdout.on('data', (buf) => {
-                const out = buf.toString();
-                out.should.have.lengthOf.greaterThan(0);
+            this.swarm.getDaemons().forEach(daemon => {
+                daemon.getProcess().stdout.on('data', (buf) => {
+                    const out = buf.toString();
+                    out.should.have.lengthOf.greaterThan(0);
+                });
             });
+        });
+
+        it('should be able to setPrimary() and getPrimary()', async function () {
+            await this.swarm.start();
+            const publicKey = this.swarm.getDaemons()[0].publicKey;
+            this.swarm.setPrimary(publicKey);
+
+            this.swarm.getPrimary().publicKey.should.equal(publicKey);
         });
     });
 
-    it('should be able to setPrimary() and getPrimary()', async function () {
-        await this.swarm.start();
-        const publicKey = this.swarm.getDaemons()[0].publicKey;
-        this.swarm.setPrimary(publicKey);
+    context('override config options', function () {
 
-        this.swarm.getPrimary().publicKey.should.equal(publicKey);
+        const configOptions = {
+            listener_port: 50050,
+            new_property: 'wow'
+        };
+
+        before('generateSwarm', async function () {
+            this.swarmManager = await swarmManager();
+            this.swarm = await this.swarmManager.generateSwarm({numberOfDaemons, configOptions});
+        });
+
+        after('stop swarm', async function () {
+            await this.swarm.stop();
+            this.swarmManager.removeSwarmState();
+        });
+
+        it('should override template listener_port', async function () {
+            this.swarm.getDaemons().forEach((config) => {
+                expect(config.listener_port).to.be.at.least(50050);
+            });
+        });
+
+        it('should include new property', async function () {
+            this.swarm.getDaemons().forEach((config) => {
+                expect(config).to.deep.include({new_property: 'wow'});
+            });
+        });
+
+        context('adding new peer', function () {
+
+            before('generate and start new peer', async function () {
+                this.swarm.addDaemon({addToRegistry: true});
+                await this.swarm.startUnstarted();
+            });
+
+            it('new peer should also have options applied', async function () {
+                expect(last(this.swarm.getDaemons()).listener_port).to.be.at.least(50050);
+                expect(last(this.swarm.getDaemons())).to.deep.include({new_property: 'wow'});
+            });
+        });
+
     });
 });
 

--- a/src/swarmManager.js
+++ b/src/swarmManager.js
@@ -25,8 +25,8 @@ exports.swarmManager = async () => {
         removeSwarmState: () => removeDaemonDirectory().run(),
     };
 
-    async function generateSwarmAndSetState({numberOfDaemons}) {
-        const swarm = await generateSwarm({esrContractAddress: getEsrContractAddress(), esrInstance, numberOfDaemons, swarmCounter, daemonCounter});
+    async function generateSwarmAndSetState({numberOfDaemons, configOptions}) {
+        const swarm = await generateSwarm({esrContractAddress: getEsrContractAddress(), esrInstance, numberOfDaemons, swarmCounter, daemonCounter, configOptions});
         setSwarms([...getSwarms(), swarm]);
 
         return swarm;

--- a/tests/shared/hooks.js
+++ b/tests/shared/hooks.js
@@ -56,10 +56,10 @@ exports.localSwarmHooks = function ({beforeHook = before, afterHook = after, cre
     stopSwarmsAndRemoveStateHook({afterHook, preserveSwarmState});
 };
 
-const localSetup = exports.localSetup = async function ({numOfNodes = harnessConfigs.numOfNodes, createDB = true, log, logDetailed} = {}) {
+const localSetup = exports.localSetup = async function ({numOfNodes = harnessConfigs.numOfNodes, createDB = true, log, logDetailed, configOptions} = {}) {
 
     const manager = await swarmManager();
-    const swarm = await manager.generateSwarm({numberOfDaemons: numOfNodes});
+    const swarm = await manager.generateSwarm({numberOfDaemons: numOfNodes, configOptions});
 
     await manager.startAll();
 

--- a/tests/shared/hooks.js
+++ b/tests/shared/hooks.js
@@ -4,7 +4,7 @@ const {wrappedError} = require('../../src/utils');
 const {log} = require('../../src/logger');
 
 
-exports.remoteSwarmHook = function ({createDB, uuid, ethereum_rpc, esrContractAddress, private_pem, public_pem, log, logDetailed}) {
+exports.remoteSwarmHook = function ({createDB, uuid, ethereum_rpc, esrContractAddress, private_pem, public_pem, log, logDetailed} = {}) {
     const clientArguments = {uuid, ethereum_rpc, esrContractAddress, private_pem, public_pem, log, logDetailed};
 
     before('initialize client and setup db', async function () {

--- a/tests/test.configurations.js
+++ b/tests/test.configurations.js
@@ -18,8 +18,8 @@ const harnessConfigs = global.harnessConfigs = {
     testRemoteSwarm: process.env.TEST_REMOTE_SWARM ? process.env.TEST_REMOTE_SWARM : false,
 
     defaultUuid: process.env.DEFAULT_UUID ? process.env.DEFAULT_UUID : '96dd6297-d8ed-4bd1-a91e-ed2958cda3c7',
-    masterPrivateKey: process.env.MASTER_PRIVATE_KEY ? process.env.MASTER_PRIVATE_KEY : 'MHQCAQEEIEOd7E9zSxgJjtpGzK/gHl0vVSOZ2iF3TY50InD67BnHoAcGBSuBBAAKoUQDQgAEE/Yeq9sYdyeou+TnNEJjMnuntrzqcFIfIHd49LW461d55TY4hVX66ZXXGvAWRqMVMeELtYuKGYU44bPaxTb1ig==',
-    masterPublicKey: process.env.MASTER_PUBLIC_KEY ? process.env.MASTER_PUBLIC_KEY : 'MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEE/Yeq9sYdyeou+TnNEJjMnuntrzqcFIfIHd49LW461d55TY4hVX66ZXXGvAWRqMVMeELtYuKGYU44bPaxTb1ig==',
+    masterPrivateKey: process.env.MASTER_PRIVATE_KEY ? process.env.MASTER_PRIVATE_KEY : 'MHcCAQEEIN1Bl1ZucJkJvkLeQXtnYeoERlrIF2OuNCo0mYi+G6tToAoGCCqGSM49AwEHoUQDQgAEWsFngpYif/xTFzASKJhdGF8QuGb2kyD+F/eVpJdWA3wQqMod/DzdCVrIl7PLJktS6UDTdh7o/h2eZYYXvI0p8w==',
+    masterPublicKey: process.env.MASTER_PUBLIC_KEY ? process.env.MASTER_PUBLIC_KEY : 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWsFngpYif/xTFzASKJhdGF8QuGb2kyD+F/eVpJdWA3wQqMod/DzdCVrIl7PLJktS6UDTdh7o/h2eZYYXvI0p8w==',
 
     ethereumRpc: process.env.ETHEREUM_RPC ? process.env.ETHEREUM_RPC : 'http://127.0.0.1:8545',
     esrContractAddress: process.env.ESR_CONTRACT_ADDRESS ? process.env.ESR_CONTRACT_ADDRESS : '0x7FDbE549D8b47b8285ff106E060Eb9C43Fd879e5',


### PR DESCRIPTION
* Add feature to pass and override daemon config options when generating a swarm
* Cleaned up `hooks.js` and `clientManager.js`  argument handling, moved defaults to lowest level
* Add db management permissioning tests

Unable to add remote swarm permissioning tests currently because testnets are not deployed with an owner set. (Without `owner_public_key` set in daemon configs, there is no permissoning, everyone is allowed to do everything.)