### PR TITLE
KEP-1493 Remove substringing ESR address

### DIFF
--- a/src/daemonManager.js
+++ b/src/daemonManager.js
@@ -206,7 +206,7 @@ const writeDaemonConfigObject = (config, swarmId) => {
 const createDaemonConfigObject = curry(({listener_port, swarm_info_esr_address, swarm_id}, template) => ({
     ...template,
     listener_port,
-    swarm_info_esr_address: swarm_info_esr_address.substr(2), // swarmDB option does not accept 0x prepended address
+    swarm_info_esr_address,
     swarm_id
 }));
 


### PR DESCRIPTION
https://bluzelle.atlassian.net/browse/KEP-1493
> The daemon should work correctly if the user sets the swarm_info_esr_address with a 0x prepended or not.

