### PR TITLE
KEP-1687 Fix swarm usage and permissioning tests

### DIFF
--- a/resources/config-template.js
+++ b/resources/config-template.js
@@ -12,5 +12,6 @@ module.exports = {
     "chaos_testing_enabled" : false,
     "logfile_rotation_size" : "5MB",
     "logfile_max_size" : "20MB",
-    "swarm_info_esr_url" : "http://127.0.0.1:8545"
+    "swarm_info_esr_url" : "http://127.0.0.1:8545",
+    "owner_public_key" : "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWsFngpYif/xTFzASKJhdGF8QuGb2kyD+F/eVpJdWA3wQqMod/DzdCVrIl7PLJktS6UDTdh7o/h2eZYYXvI0p8w=="
 };

--- a/tests/functional/database-management.test.js
+++ b/tests/functional/database-management.test.js
@@ -9,7 +9,7 @@ describe('database management', function () {
 
     context('database creation and deletion', function () {
 
-        (harnessConfigs.testRemoteSwarm ? context.skip : context)('permissioning', function () {
+        (harnessConfigs.testRemoteSwarm ? context.only : context)('permissioning', function () {
 
             const randomUuid = `${Math.random()}`;
 
@@ -22,7 +22,6 @@ describe('database management', function () {
             (harnessConfigs.testRemoteSwarm
                 ? remoteSwarmHook({
                     createDB: false,
-                    uuid: randomUuid,
                     private_pem: harnessConfigs.masterPrivateKey,
                     public_pem: harnessConfigs.masterPublicKey
                 })

--- a/tests/functional/database-management.test.js
+++ b/tests/functional/database-management.test.js
@@ -11,8 +11,6 @@ describe('database management', function () {
 
         (harnessConfigs.testRemoteSwarm ? context.only : context)('permissioning', function () {
 
-            const randomUuid = `${Math.random()}`;
-
             const [pubKey, privKey] = generateEllipticCurveKeys(`/tmp`);
             const notMasterKeyPair = {
                 privateKey: privKey,
@@ -75,7 +73,6 @@ describe('database management', function () {
 
                     const apis = await initializeClient({
                         createDB: false,
-                        uuid: randomUuid,
                         esrContractAddress: this.esrAddress,
                         private_pem: notMasterKeyPair.privateKey,
                         public_pem: notMasterKeyPair.publicKey
@@ -115,7 +112,7 @@ describe('database management', function () {
                     });
 
                     it('should fail to updateDB', async function () {
-                        await this.noAccessApi._updateDB().should.be.rejectedWith('DATABASE_NOT_FOUND')
+                        await this.noAccessApi._updateDB().should.be.rejectedWith('ACCESS_DENIED')
                     });
 
                     it('should fail to deleteDB', async function () {

--- a/tests/functional/status.test.js
+++ b/tests/functional/status.test.js
@@ -13,9 +13,10 @@ const {find} = require('lodash');
 
     const modules = [];
 
-    (harnessConfigs.testRemoteSwarm ? remoteSwarmHook() : localSwarmHooks({configOptions: {max_swarm_storage: testParams.maxSwarmStorage}}));
+    (harnessConfigs.testRemoteSwarm ? remoteSwarmHook() : localSwarmHooks({createDB: false, configOptions: {max_swarm_storage: testParams.maxSwarmStorage}}));
 
     before('make status request', async function () {
+        await this.api._createDB(Math.floor(testParams.maxSwarmStorage/testParams.numberOfNamespaces));
         this.response = await this.api.status();
         JSON.parse(this.response.moduleStatusJson).module.forEach(module => modules.push(module));
     });
@@ -51,7 +52,7 @@ const {find} = require('lodash');
         });
 
         it('should report correct swarm_storage_usage', function () {
-            expect(this.crudModuleResponse.status).to.deep.include({'swarm_storage_usage': testParams.namespaceSize * testParams.numberOfNamespaces})
+            expect(this.crudModuleResponse.status).to.deep.include({'swarm_storage_usage': Math.floor(testParams.maxSwarmStorage / testParams.numberOfNamespaces)+ testParams.namespaceSize * testParams.numberOfNamespaces})
         });
 
         it('should report correct max_swarm_storage', function () {

--- a/tests/test.configurations.js
+++ b/tests/test.configurations.js
@@ -23,7 +23,7 @@ const harnessConfigs = global.harnessConfigs = {
 
     ethereumRpc: process.env.ETHEREUM_RPC ? process.env.ETHEREUM_RPC : 'http://127.0.0.1:8545',
     esrContractAddress: process.env.ESR_CONTRACT_ADDRESS ? process.env.ESR_CONTRACT_ADDRESS : '0x7FDbE549D8b47b8285ff106E060Eb9C43Fd879e5',
-    maxSwarmStorage: process.env.MAX_SWARM_STORAGE ? process.env.MAX_SWARM_STORAGE : 20000,
+    maxSwarmStorage: process.env.MAX_SWARM_STORAGE ? process.env.MAX_SWARM_STORAGE : 200000,
 
     initialDaemonListenerPort: 50000,
 


### PR DESCRIPTION
* Turn on database access permissioning tests for remote testing
* Fixed test issue with no owner swarm returning a different response than an `owner_public_key` declared swarm
* Updated `swarm_storage_usage` math 
** Although I don't quite understand why that is the expected answer 