### PR TITLE
KEP-1745 Fix startup.test.js hooks

### DIFF
--- a/tests/integration/startup.test.js
+++ b/tests/integration/startup.test.js
@@ -102,7 +102,9 @@ describe('daemon startup', function () {
 
                 this.output = '';
 
-                this.daemon = launchDaemon(['-c', DAEMON_OBJ.config_name]).stdout
+                this.daemon = launchDaemon(['-c', DAEMON_OBJ.config_name]);
+
+                this.daemon.stdout
                     .pipe(split2())
                     .on('data', line => {
                         this.output += line;


### PR DESCRIPTION
Was assigning stdout stream to this.daemon instead of the subprocess itself